### PR TITLE
Remove non-existent `browser` entry-point from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "4.1.2",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
-  "browser": "lib/cjs/browser.js",
   "typings": "lib/cjs/index.d.ts",
   "repository": "https://github.com/franckLdx/ts-retry.git",
   "author": "Franck Ledoux <franck.ledoux.pro@gmail.com>",


### PR DESCRIPTION
Greetings,

The `package.json` file seems to be referencing a non-existent entry-point for bundlers/browsers via the `browser` key:

https://github.com/franckLdx/ts-retry/blob/7f70c0b0b78627bd9905bfefe6f43b9483c503c3/package.json#L6

This causes React Native to fail building if `ts-retry` is one of the dependencies. I have gone ahead and simply deleted the line. Apologies if it serves a purpose I'm missing or if there's a better solution to my problem.

Thanks!